### PR TITLE
Validate denom and URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,19 +193,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "cw-blotto"
-version = "0.1.0"
+name = "cw-denom"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c8b429a0bc3a43d84a20086169665284e19c0cfd3669a4a80c2c8a3bfa45d05"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.0.1",
- "cw-utils 1.0.1",
- "cw2 1.0.1",
- "cw20",
- "cw721 0.17.0",
- "cw721-base 0.17.0",
- "schemars",
- "serde",
+ "cw20 0.16.0",
  "thiserror",
 ]
 
@@ -315,6 +310,19 @@ dependencies = [
 
 [[package]]
 name = "cw20"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45a8794a5dd33b66af34caee52a7beceb690856adcc1682b6e3db88b2cdee62"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils 0.16.0",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw20"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91666da6c7b40c8dd5ff94df655a28114efc10c79b70b4d06f13c31e37d60609"
@@ -394,15 +402,17 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-denom",
  "cw-storage-plus 1.0.1",
  "cw-utils 1.0.1",
  "cw2 1.0.1",
- "cw20",
+ "cw20 1.0.1",
  "cw721 0.17.0",
  "cw721-base 0.17.0",
  "schemars",
  "serde",
  "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -510,6 +520,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "forward_ref"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +591,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +635,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pkcs8"
@@ -861,6 +896,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,10 +929,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "version_check"

--- a/contracts/cw721-piggy-bank/Cargo.toml
+++ b/contracts/cw721-piggy-bank/Cargo.toml
@@ -29,3 +29,4 @@ cw721-base      = { version = "0.17.0", features = ["library"] }
 schemars        = "0.8.11"
 serde           = { version = "1.0.152", default-features = false, features = ["derive"] }
 thiserror       = "1.0.30"
+url             = "2.2.2"

--- a/contracts/cw721-piggy-bank/Cargo.toml
+++ b/contracts/cw721-piggy-bank/Cargo.toml
@@ -30,3 +30,4 @@ schemars        = "0.8.11"
 serde           = { version = "1.0.152", default-features = false, features = ["derive"] }
 thiserror       = "1.0.30"
 url             = "2.2.2"
+cw-denom       = "2.0.2"

--- a/contracts/cw721-piggy-bank/src/contract.rs
+++ b/contracts/cw721-piggy-bank/src/contract.rs
@@ -36,12 +36,12 @@ pub fn instantiate(
 
     // Validate denoms are formatted correctly
     let unchecked_denom = UncheckedDenom::Native(msg.deposit_denom.clone());
-    let _checked_denom = unchecked_denom.into_checked(deps.as_ref()).map_err(|_| StdError::generic_err("Invalid deposit denom"))?;
+    let checked_denom = unchecked_denom.into_checked(deps.as_ref()).map_err(|_| StdError::generic_err("Invalid deposit denom"))?;
     
     // Save config info
-    DEPOSIT_DENOM.save(deps.storage, &_checked_denom.to_string())?;
+    DEPOSIT_DENOM.save(deps.storage, &checked_denom.to_string())?;
     // validate base_url is a real url
-    let _parsed_url = Url::parse(&msg.base_url).map_err(|_| StdError::generic_err("Invalid base URL"))?;
+    Url::parse(&msg.base_url).map_err(|_| StdError::generic_err("Invalid base URL"))?;
     BASE_URL.save(deps.storage, &msg.base_url)?;
     MINT_PRICE.save(deps.storage, &msg.mint_price)?;
     if let Some(max_nft_supply) = msg.max_nft_supply {

--- a/contracts/cw721-piggy-bank/src/contract.rs
+++ b/contracts/cw721-piggy-bank/src/contract.rs
@@ -8,6 +8,7 @@ pub use cw721_base::{
     ContractError as BaseContractError, InstantiateMsg as BaseInstantiateMsg, MinterResponse,
 };
 use cw_utils::must_pay;
+use url::Url;
 
 use crate::{
     msg::{Cw721Contract, ExecuteExt, ExecuteMsg, InstantiateMsg, MetadataExt, QueryExt, QueryMsg},
@@ -36,7 +37,8 @@ pub fn instantiate(
 
     // Save config info
     DEPOSIT_DENOM.save(deps.storage, &msg.deposit_denom)?;
-    // TODO validate base_url is a real url
+    // validate base_url is a real url
+    let _parsed_url = Url::parse(&msg.base_url).map_err(|_| StdError::generic_err("Invalid base URL"))?;
     BASE_URL.save(deps.storage, &msg.base_url)?;
     MINT_PRICE.save(deps.storage, &msg.mint_price)?;
     if let Some(max_nft_supply) = msg.max_nft_supply {

--- a/contracts/cw721-piggy-bank/src/contract.rs
+++ b/contracts/cw721-piggy-bank/src/contract.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::{
     entry_point, to_binary, BankMsg, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response,
     StdError, StdResult, Uint128,
 };
+use cw_denom::UncheckedDenom;
 pub use cw721_base::{
     ContractError as BaseContractError, InstantiateMsg as BaseInstantiateMsg, MinterResponse,
 };
@@ -33,10 +34,12 @@ pub fn instantiate(
 ) -> StdResult<Response> {
     cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-    // TODO Validate denoms are formated correctly
-
+    // Validate denoms are formatted correctly
+    let unchecked_denom = UncheckedDenom::Native(msg.deposit_denom.clone());
+    let _checked_denom = unchecked_denom.into_checked(deps.as_ref()).map_err(|_| StdError::generic_err("Invalid deposit denom"))?;
+    
     // Save config info
-    DEPOSIT_DENOM.save(deps.storage, &msg.deposit_denom)?;
+    DEPOSIT_DENOM.save(deps.storage, &_checked_denom.to_string())?;
     // validate base_url is a real url
     let _parsed_url = Url::parse(&msg.base_url).map_err(|_| StdError::generic_err("Invalid base URL"))?;
     BASE_URL.save(deps.storage, &msg.base_url)?;

--- a/contracts/cw721-piggy-bank/src/contract.rs
+++ b/contracts/cw721-piggy-bank/src/contract.rs
@@ -1,5 +1,3 @@
-use std::fmt::format;
-
 use cosmwasm_std::{
     entry_point, to_binary, BankMsg, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response,
     StdError, StdResult, Uint128,

--- a/contracts/cw721-piggy-bank/src/msg.rs
+++ b/contracts/cw721-piggy-bank/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Coin, CustomMsg, Empty, Uint128};
+use cosmwasm_std::{Coin, CustomMsg, Empty};
 
 // Implements extended on-chain metadata, by default cw721 NFTs only store a
 // token_uri, which is a URL to off-chain metadata (same as ERC721).


### PR DESCRIPTION
The validation works when changing `tests.rs`. Was unsure about types to use in `state.rs` so I kept them as strings.

Also, if I try to pipe the URL into the URL state...the `token_uri` assertion fails. 

`BASE_URL.save(deps.storage, &_parsed_url.to_string())?;`
`    assert_eq!(token.info.token_uri, Some("https://bafybeie2grcflzjvds7i33bxjjgktjdfcp2h2v27gdkbyuiaelvbgtdewy.ipfs.nftstorage.link/1/seedling.json".to_string()));`
